### PR TITLE
fix: gracefully handle git blame errors to handle deleting empty files

### DIFF
--- a/difflame.py
+++ b/difflame.py
@@ -76,7 +76,10 @@ def run_git_blame(arguments):
     if len(BLAME_OPTIONS) > 0:
         args.extend(BLAME_OPTIONS)
     args.extend(arguments)
-    return run_git_command(args)
+    try:
+        return run_git_command(args)
+    except subprocess.CalledProcessError:
+        return ""
 
 def run_git_diff(arguments):
     '''


### PR DESCRIPTION
When running `difflame.py` on a commit that deletes an empty file, the git blame command gets called when it probably should not. There's some logic in `get_blame_info_hunk()` that could probably be adjusted to more cleanly fix #6, but this try/catch statement does the trick, though maybe in a somewhat hacky way.

This patch allows the program to work without error when faced with a commit that deletes an empty file, but it does cause a warning to get printed, like this, which is not ideal but better than a crash:

```
Processing line 0/4fatal: no such path empty in 2dbfc2d38350b66b673c0bc841c3b10349dd44ef
Processing line 4/4
diff --git a/empty b/empty
deleted file mode 100644
index e69de29..0000000
```

Fixes: https://github.com/eantoranz/difflame/issues/6